### PR TITLE
[Secondary Display] Implement PresentationHelper and BasePresentation

### DIFF
--- a/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
+++ b/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.kevo.displaydemo
 
 import android.os.Bundle
+import android.view.Display
 import android.view.Menu
 import android.view.MenuItem
 import com.google.android.material.snackbar.Snackbar
@@ -13,11 +14,16 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import androidx.appcompat.app.AppCompatActivity
 import com.kevo.displaydemo.databinding.ActivityMainBinding
+import com.kevo.displaydemo.ui.secondarydisplay.BasePresentation
+import com.kevo.displaydemo.ui.secondarydisplay.PresentationHelper
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), PresentationHelper.Listener {
 
     private lateinit var appBarConfiguration: AppBarConfiguration
     private lateinit var binding: ActivityMainBinding
+
+    private lateinit var presentationHelper: PresentationHelper
+    private var preso: BasePresentation? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +60,18 @@ class MainActivity : AppCompatActivity() {
             setupActionBarWithNavController(navController, appBarConfiguration)
             it.setupWithNavController(navController)
         }
+
+        presentationHelper = PresentationHelper(this, this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        presentationHelper.onResume()
+    }
+
+    override fun onPause() {
+        presentationHelper.onPause()
+        super.onPause()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -82,5 +100,15 @@ class MainActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         val navController = findNavController(R.id.nav_host_fragment_content_main)
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+    }
+
+    override fun showPreso(display: Display) {
+        preso = BasePresentation(this, display)
+        preso?.show()
+    }
+
+    override fun clearPreso(showInLine: Boolean) {
+        preso?.dismiss()
+        preso = null
     }
 }

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/BasePresentation.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/BasePresentation.kt
@@ -1,0 +1,16 @@
+package com.kevo.displaydemo.ui.secondarydisplay
+
+import android.app.Presentation
+import android.content.Context
+import android.os.Bundle
+import android.view.Display
+import com.kevo.displaydemo.R
+
+class BasePresentation (context: Context, display: Display): Presentation(context, display) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.second_screen_logo)
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationHelper.kt
@@ -1,0 +1,108 @@
+package com.kevo.displaydemo.ui.secondarydisplay
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.hardware.display.DisplayManager.DisplayListener
+import android.util.Log
+import android.view.Display
+
+/**
+ * Manages listening to DisplayManager display state changes and using display manager to setup a
+ * Presentation to display on a secondary screen.
+ *
+ * In order to use PresentationHelper forward your Activity/Fragment onResume()/onPause() callbacks
+ * to [PresentationHelper.onResume] and [PresentationHelper.onPause] respectively so it can set
+ * things up and clean up after itself.
+ */
+class PresentationHelper(val context: Context, val listener: Listener): DisplayListener {
+    private var isFirstRun = true
+    private var manager: DisplayManager? = null
+    private var currentDisplay: Display? = null
+
+    // Get the DisplayManager and register ourself as a listener for display changes
+    fun onResume() {
+        manager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+        handleRoute()
+        manager?.registerDisplayListener(this, null)
+    }
+
+    // Do housekeeping to clear the current display and unregister ourself from the DisplayManager
+    fun onPause() {
+        listener.clearPreso(false)
+        currentDisplay = null
+        manager?.unregisterDisplayListener(this)
+    }
+
+    /**
+     * Handles most of the business logic for getting a potential display to use from the
+     * DisplayManager and setting it up depending on our current state. IE: Whether we're setting
+     * up a new display for the first time, swapping from a disconnected display to a newly
+     * connected display, or the display we were using was simply disconnected and we have to
+     * stop what we were doing.
+     */
+    private fun handleRoute() {
+        if (manager == null) {
+            Log.i(TAG, "handleRoute() called but DisplayManager is null!")
+            return
+        }
+
+        // Get a list of all displays sorted with the best option for a secondary display first
+        val displays = manager!!.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
+
+        if (displays.isEmpty()) {
+            // No valid display is connected so clear the current presentation if we haven't already
+            if (currentDisplay != null || isFirstRun) {
+                listener.clearPreso(true)
+                currentDisplay = null
+            }
+        } else {
+            // At least one valid secondary display is present for us to setup
+            // TODO test if this code still runs if there is only 1 display (the main one)
+            //  ideally it doesn't
+            val newDisplay: Display = displays[0]
+
+            if (newDisplay.isValid) {
+                if (currentDisplay == null) {
+                    // The new display is valid and there is no old one to clear
+                    listener.showPreso(newDisplay)
+                    currentDisplay = newDisplay
+                } else if (currentDisplay?.displayId != newDisplay.displayId) {
+                    // The new display is valid and an the old one needs to be cleared
+                    listener.clearPreso(true)
+                    listener.showPreso(newDisplay)
+                    currentDisplay = newDisplay
+                }
+            } else if (currentDisplay != null) {
+                // The new display is invalid (possibly disconnected) so we must assume there are
+                // no good displays and clear the current one
+                listener.clearPreso(true)
+                currentDisplay = null
+            }
+        }
+
+        isFirstRun = false
+    }
+
+    // Anytime there's a display change we want to run handleRoute() to perform any required changes
+    override fun onDisplayAdded(p0: Int) {
+        handleRoute()
+    }
+
+    override fun onDisplayRemoved(p0: Int) {
+        handleRoute()
+    }
+
+    override fun onDisplayChanged(p0: Int) {
+        handleRoute()
+    }
+
+    interface Listener {
+        fun showPreso(display: Display)
+
+        fun clearPreso(showInLine: Boolean)
+    }
+
+    companion object {
+        const val TAG = "PresentationHelper"
+    }
+}

--- a/app/src/main/res/layout/second_screen_logo.xml
+++ b/app/src/main/res/layout/second_screen_logo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/second_screen_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hi I'm the secondary screen!"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:textSize="24dp"/>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Summary:
- Add the PresentationHelper that listens to the DisplayManager to get access to the secondary screen and invoke any required methods to display a Presentation on it.

- Create BasePresentation which is a very simple implementation of Presentation we can use to display content on a secondary screen.

Test Plan:
- Open the app on a device that has a secondary screen
- Verify You see "Hi I'm the secondary screen!" displayed on the secondary screen