### PR TITLE
Add Accessory Display Service boilerplate and fix Theme Resource ID crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <!-- Include required permissions for Google Mobile Ads to run. -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"
@@ -16,6 +17,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidPresentationDisplayDemo"
         tools:targetApi="31">
+
+        <!-- Accessory Display -->
+        <service
+            android:name=".service.AccessoryDisplayService"
+            android:exported="false" />
 
         <!--
         You can find your app ID in the AdMob UI. For android:value,

--- a/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
+++ b/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
@@ -4,20 +4,25 @@ import android.os.Bundle
 import android.view.Display
 import android.view.Menu
 import android.view.MenuItem
-import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.navigation.NavigationView
+import android.widget.TextView
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
-import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.navigation.NavigationView
+import com.google.android.material.snackbar.Snackbar
 import com.kevo.displaydemo.databinding.ActivityMainBinding
+import com.kevo.displaydemo.service.ServiceManager
+import com.kevo.displaydemo.ui.BaseActivity
 import com.kevo.displaydemo.ui.secondarydisplay.PresentationHelper
 import com.kevo.displaydemo.ui.secondarydisplay.SimplePresentationFragment
+import com.kevo.displaydemo.util.DeviceHelper
 
-class MainActivity : AppCompatActivity(), PresentationHelper.Listener {
+class MainActivity : BaseActivity(), PresentationHelper.Listener {
+
+    override val TAG: String = "MainActivity"
 
     private lateinit var appBarConfiguration: AppBarConfiguration
     private lateinit var binding: ActivityMainBinding
@@ -52,6 +57,11 @@ class MainActivity : AppCompatActivity(), PresentationHelper.Listener {
                 ),
                 binding.drawerLayout
             )
+
+            // FIXME: This isn't working ...
+            // Update Nav Drawer subtitle to show the Device Family Identifier
+            it.findViewById<TextView>(R.id.nav_header_subtitle)?.text =
+                    DeviceHelper.generateDeviceFamilyIdentifier()
             setupActionBarWithNavController(navController, appBarConfiguration)
             it.setupWithNavController(navController)
         }
@@ -75,6 +85,7 @@ class MainActivity : AppCompatActivity(), PresentationHelper.Listener {
 
     override fun onResume() {
         super.onResume()
+        ServiceManager.getInstance().startAccessoryDisplayService(application)
         presentationHelper.onResume()
     }
 
@@ -112,7 +123,7 @@ class MainActivity : AppCompatActivity(), PresentationHelper.Listener {
     }
 
     override fun showPreso(display: Display) {
-        preso = SimplePresentationFragment(this, display)
+        preso = SimplePresentationFragment(this, themeResourceId, display)
         preso!!.show(supportFragmentManager, SimplePresentationFragment.TAG)
     }
 

--- a/app/src/main/java/com/kevo/displaydemo/app/Intent.kt
+++ b/app/src/main/java/com/kevo/displaydemo/app/Intent.kt
@@ -1,0 +1,22 @@
+package com.kevo.displaydemo.app
+
+// TODO: This is a work in progress ...
+object Intent {
+
+    object Extra {
+
+        // Secondary Accessory (Customer Facing) Display
+        /**
+         * Start and bind the Accessory Display service to our application.
+         */
+        const val ACCESSORY_DISPLAY_START = "accessory_display_start"
+    }
+
+    object Action {
+
+        const val STOP_SERVICE = "stop_service"
+    }
+
+    object Builder {
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/app/IntentExtras.kt
+++ b/app/src/main/java/com/kevo/displaydemo/app/IntentExtras.kt
@@ -1,0 +1,10 @@
+package com.kevo.displaydemo.app
+
+object IntentExtras {
+
+    // Secondary Accessory (Customer Facing) Display
+    /**
+     * Start and bind the Accessory Display service to our application.
+     */
+    const val ACCESSORY_DISPLAY_START = "accessory_display_start"
+}

--- a/app/src/main/java/com/kevo/displaydemo/service/AccessoryDisplayService.kt
+++ b/app/src/main/java/com/kevo/displaydemo/service/AccessoryDisplayService.kt
@@ -1,0 +1,126 @@
+package com.kevo.displaydemo.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.annotation.DrawableRes
+import androidx.core.app.NotificationCompat
+import com.kevo.displaydemo.R
+
+class AccessoryDisplayService : Service() {
+
+    private var isForeground = false
+    private var isBound = false
+
+    /**
+     * [Binder] for the [AccessoryDisplayService].
+     */
+    inner class ServiceBinder : Binder() {
+
+        var service: AccessoryDisplayService = this@AccessoryDisplayService
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "onCreate -> Service is being created ...")
+
+        isForeground = true
+        startForeground(REGISTER_ACCESSORY_DISPLAY_SERVICE, getNotification())
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        Log.d(TAG, "onStartCommand -> Command configuration: $intent / $flags / $startId")
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent): IBinder {
+        Log.d(TAG, "onBind -> Service bound using $intent")
+        return ServiceBinder()
+    }
+
+    override fun onUnbind(intent: Intent): Boolean {
+        Log.d(TAG, "onUnbind -> Service un-bound with $intent")
+        isBound = false
+        return true
+    }
+
+    override fun onRebind(intent: Intent) {
+        super.onRebind(intent)
+        Log.d(TAG, "onRebind -> Service is being re-binded using $intent")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "onDestroy -> Service is being destroyed ...")
+    }
+
+    fun handleIntent(intent: Intent) {
+        Log.w(TAG, "Handling Intents is not supported yet ...")
+    }
+
+    private fun getNotification(): Notification {
+        /*
+        Since Android 8 (Oreo) a Notification Channel must be configured, otherwise you will
+        get this runtime crash:
+
+        FATAL EXCEPTION: main
+        Process: com.kevo.displaydemo, PID: 11754
+        kotlin.NotImplementedError: An operation is not implemented: Not yet implemented
+          at com.kevo.displaydemo.service.AccessoryDisplayService.onBind(AccessoryDisplayService.kt:53)
+          at android.app.ActivityThread.handleBindService(ActivityThread.java:3980)
+          at android.app.ActivityThread.access$1600(ActivityThread.java:219)
+          at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1880)
+          at android.os.Handler.dispatchMessage(Handler.java:107)
+          at android.os.Looper.loop(Looper.java:214)
+          at android.app.ActivityThread.main(ActivityThread.java:7356)
+          at java.lang.reflect.Method.invoke(Native Method)
+          at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
+          at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
+
+         */
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name: String = getString(R.string.notification_accessorydisplayservice_channel_name)
+            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance)
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager?.createNotificationChannel(channel)
+        }
+
+        // TODO: Support dynamic changing of the Status Icon
+        @DrawableRes val smallIcon = R.drawable.ic_fa_layers_half
+        // if (!isConnected) {
+        //     smallIcon = android.R.drawable.stat_notify_error
+        // }
+
+        // TODO: Build Status Bar Notifications for "Stopping" service (and other states)
+
+        val notificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(smallIcon)
+                .setContentTitle(
+                    getString(R.string.notification_accessorydisplayservice_content_title))
+                .setContentText(
+                    getString(R.string.notification_accessorydisplayservice_content_text))
+                .setTicker(getString(R.string.notification_accessorydisplayservice_ticker))
+                .setAutoCancel(true)
+                .setShowWhen(false)
+                .setContentIntent(null)
+
+        return notificationBuilder.build()
+    }
+
+    companion object {
+
+        private const val TAG = "AccessoryDisplayService"
+
+        private const val NOTIFICATION_CHANNEL_ID = "AccessoryDisplayService"
+
+        // This is a unique ID that should be defined in an apps Constants file.
+        private const val REGISTER_ACCESSORY_DISPLAY_SERVICE = 2
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/service/AccessoryDisplayService.kt
+++ b/app/src/main/java/com/kevo/displaydemo/service/AccessoryDisplayService.kt
@@ -41,6 +41,8 @@ class AccessoryDisplayService : Service() {
 
     override fun onBind(intent: Intent): IBinder {
         Log.d(TAG, "onBind -> Service bound using $intent")
+        // TODO: Refine the Service implementation
+        isBound = true
         return ServiceBinder()
     }
 
@@ -61,6 +63,7 @@ class AccessoryDisplayService : Service() {
     }
 
     fun handleIntent(intent: Intent) {
+        // TODO: Support Intent handling for component communication relays
         Log.w(TAG, "Handling Intents is not supported yet ...")
     }
 

--- a/app/src/main/java/com/kevo/displaydemo/service/ServiceManager.kt
+++ b/app/src/main/java/com/kevo/displaydemo/service/ServiceManager.kt
@@ -1,0 +1,82 @@
+package com.kevo.displaydemo.service
+
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.util.Log
+import com.kevo.displaydemo.app.Intent.Action
+import com.kevo.displaydemo.app.IntentExtras
+
+/**
+ * Singleton that retains a reference to service bindings that can be used to relay
+ * instructions to the service.
+ */
+class ServiceManager private constructor() {
+
+    // TODO: I'm not real comfortable with this approach of holding a forever reference to
+    //  a Service instance in the scope of a Singleton - smells like it could be a bad design.
+    //  However, the onServiceDisconnected() should nullify it.
+    private var accessoryDisplayService: AccessoryDisplayService? = null
+
+    fun startAccessoryDisplayService(app: Context) {
+        val intent = Intent(app, AccessoryDisplayService::class.java).apply {
+            putExtra(IntentExtras.ACCESSORY_DISPLAY_START, true)
+        }
+
+        Log.i(TAG, "Sending instruction to start the Accessory Display service ...")
+        sendToService(app, intent)
+    }
+
+    // TODO: This is a work in progress ...
+    fun stopAccessoryDisplayService(app: Context): PendingIntent {
+        val intent = Intent(app, AccessoryDisplayService::class.java).apply {
+            action = Action.STOP_SERVICE
+        }
+
+        return PendingIntent.getService(app, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+    }
+
+    private fun sendToService(app: Context, intent: Intent) {
+        if (accessoryDisplayService != null) {
+            accessoryDisplayService?.handleIntent(intent)
+        } else {
+            Log.i(TAG, "Creating new service connection ...")
+            app.bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE)
+        }
+    }
+
+    private val serviceConnection: ServiceConnection = object : ServiceConnection {
+
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            Log.i(TAG, "Service connected. Name: $name / Binder: $binder")
+            val serviceBinder = binder as AccessoryDisplayService.ServiceBinder
+            accessoryDisplayService = serviceBinder.service
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            Log.i(TAG, "Service disconnected. Name: $name")
+            accessoryDisplayService = null
+        }
+    }
+
+    companion object {
+
+        private const val TAG = "ServiceManager"
+
+        @Volatile
+        private lateinit var instance: ServiceManager
+
+        @JvmStatic
+        fun getInstance(): ServiceManager {
+            synchronized(this) {
+                if (!::instance.isInitialized) {
+                    instance = ServiceManager()
+                }
+                return instance
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/BaseActivity.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/BaseActivity.kt
@@ -1,0 +1,18 @@
+package com.kevo.displaydemo.ui
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+
+abstract class BaseActivity : AppCompatActivity() {
+
+    @Suppress("PropertyName")
+    protected abstract val TAG: String
+
+    protected var themeResourceId: Int = 0
+
+    override fun setTheme(resId: Int) {
+        super.setTheme(resId)
+        Log.i(TAG, "Setting Theme ID: $resId")
+        themeResourceId = resId
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationFragment.kt
@@ -4,10 +4,12 @@ import android.app.Dialog
 import android.app.Presentation
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.Display
 import androidx.fragment.app.DialogFragment
 
-open class PresentationFragment: DialogFragment() {
+open class PresentationFragment : DialogFragment() {
+
     private var display: Display? = null
     private var preso: Presentation? = null
 
@@ -19,11 +21,30 @@ open class PresentationFragment: DialogFragment() {
         }
     }
 
-    fun setDisplay(context: Context, display: Display?) {
+    fun setDisplay(themedContext: Context, themeResourceId: Int, display: Display?) {
         if (display == null) {
             preso = null
         } else {
-            preso = Presentation(context, display, theme)
+            if (themeResourceId == 0) {
+                Log.w(
+                    TAG,
+                    "The Theme Resource ID has not been initialized. The app will probably crash."
+                )
+            }
+
+            /*
+            Currently, we must past a Theme Resource ID, and if we don't pass the right Theme
+            Resource ID, we will get an InflateException crash:
+
+            Caused by: java.lang.IllegalArgumentException: The style on this component requires your app theme to be
+            Theme.MaterialComponents (or a descendant).
+              at com.google.android.material.internal.ThemeEnforcement.checkTheme(ThemeEnforcement.java:243)
+              at com.google.android.material.internal.ThemeEnforcement.checkMaterialTheme(ThemeEnforcement.java:217)
+              at com.google.android.material.internal.ThemeEnforcement.checkCompatibleTheme(ThemeEnforcement.java:145)
+              at com.google.android.material.internal.ThemeEnforcement.obtainStyledAttributes(ThemeEnforcement.java:76)
+              at com.google.android.material.button.MaterialButton.<init>(MaterialButton.java:229)
+             */
+            preso = Presentation(themedContext, display, themeResourceId)
         }
 
         this.display = display
@@ -37,5 +58,10 @@ open class PresentationFragment: DialogFragment() {
         } else {
             super.getContext()
         }
+    }
+
+    companion object {
+
+        const val TAG = "PresentationFragment"
     }
 }

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/PresentationFragment.kt
@@ -33,7 +33,7 @@ open class PresentationFragment : DialogFragment() {
             }
 
             /*
-            Currently, we must past a Theme Resource ID, and if we don't pass the right Theme
+            Currently, we must pass a Theme Resource ID, and if we don't pass the right Theme
             Resource ID, we will get an InflateException crash:
 
             Caused by: java.lang.IllegalArgumentException: The style on this component requires your app theme to be

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
@@ -1,30 +1,63 @@
 package com.kevo.displaydemo.ui.secondarydisplay
 
+import android.app.Presentation
 import android.content.Context
 import android.os.Bundle
 import android.view.Display
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.kevo.displaydemo.R
+import com.kevo.displaydemo.databinding.SecondScreenLogoBinding
+import com.kevo.displaydemo.util.SnackbarHelper
 
-class SimplePresentationFragment(context: Context, display: Display): PresentationFragment() {
+/**
+ * @param themedContext Should be a View context that contains UI theme information.
+ * The "Application" context may not contain the needed theme details to inflate the
+ * [PresentationFragment].
+ * @param themeResourceId For whatever reason, the Android architects did not provide
+ * a convenient way to determine the Theme Resource ID, which is required by the native
+ * [Presentation] class to function properly.
+ */
+class SimplePresentationFragment(
+    themedContext: Context,
+    themeResourceId: Int,
+    display: Display,
+) : PresentationFragment() {
+
+    private var _binding: SecondScreenLogoBinding? = null
+    private val binding get() = _binding!!
 
     init {
-        setDisplay(context, display)
+        setDisplay(themedContext, themeResourceId, display)
     }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        val view = inflater.inflate(R.layout.second_screen_logo, container, false)
+    ): View {
+        _binding = SecondScreenLogoBinding.inflate(inflater, container, false).apply {
+            btnRed.setOnClickListener {
+                SnackbarHelper.showLong(it, "You clicked the Red button")
+            }
+            btnYellow.setOnClickListener {
+                SnackbarHelper.showLong(it, "You clicked the Yellow button")
+            }
+            btnGreen.setOnClickListener {
+                SnackbarHelper.showLong(it, "You clicked the Green button")
+            }
+        }
 
-        return view.rootView
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     companion object {
+
         const val TAG = "SimplePresentationFragment"
     }
 }

--- a/app/src/main/java/com/kevo/displaydemo/util/DeviceHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/util/DeviceHelper.kt
@@ -1,0 +1,23 @@
+package com.kevo.displaydemo.util
+
+import android.os.Build
+
+object DeviceHelper {
+
+    /**
+     * Examples:
+     * PAX/A920
+     * LANDI/APOS A8OVS
+     * LANDI/DX8000
+     * Elo Touch Solutions/Elo-PP-15
+     * Elo Touch Solutions/15in-I-Series-4-USBC-V
+     */
+    @JvmStatic
+    fun generateDeviceFamilyIdentifier() = "${Build.MANUFACTURER}/${Build.MODEL}"
+
+    @JvmStatic
+    fun isEloZ30(): Boolean = generateDeviceFamilyIdentifier().equals(
+        "Elo Touch Solutions/15in-I-Series-4-USBC-V",
+        ignoreCase = true
+    )
+}

--- a/app/src/main/java/com/kevo/displaydemo/util/DeviceHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/util/DeviceHelper.kt
@@ -15,6 +15,8 @@ object DeviceHelper {
     @JvmStatic
     fun generateDeviceFamilyIdentifier() = "${Build.MANUFACTURER}/${Build.MODEL}"
 
+    // TODO: The Elo Z10 has the same device identifier. If we need to know whether the device
+    //  has a Customer Facing Display plugged in, we'll need to come up with a different solution.
     @JvmStatic
     fun isEloZ30(): Boolean = generateDeviceFamilyIdentifier().equals(
         "Elo Touch Solutions/15in-I-Series-4-USBC-V",

--- a/app/src/main/java/com/kevo/displaydemo/util/SnackbarHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/util/SnackbarHelper.kt
@@ -1,0 +1,12 @@
+package com.kevo.displaydemo.util
+
+import android.view.View
+import com.google.android.material.snackbar.Snackbar
+
+object SnackbarHelper {
+
+    @JvmStatic
+    fun showLong(view: View, message: String) {
+        Snackbar.make(view, message, Snackbar.LENGTH_LONG).setAction("Cool", null).show()
+    }
+}

--- a/app/src/main/res/drawable/ic_fa_layers_half.xml
+++ b/app/src/main/res/drawable/ic_fa_layers_half.xml
@@ -1,0 +1,10 @@
+<!-- Angular Bootstrap - Font Awesome - Layers Half -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:fillColor="#000"
+        android:pathData="M8.235,1.559a0.5,0.5 0,0 0,-0.47 0l-7.5,4a0.5,0.5 0,0 0,0 0.882L3.188,8 0.264,9.559a0.5,0.5 0,0 0,0 0.882l7.5,4a0.5,0.5 0,0 0,0.47 0l7.5,-4a0.5,0.5 0,0 0,0 -0.882L12.813,8l2.922,-1.559a0.5,0.5 0,0 0,0 -0.882l-7.5,-4zM8,9.433 L1.562,6 8,2.567 14.438,6 8,9.433z" />
+</vector>

--- a/app/src/main/res/layout/nav_header_main.xml
+++ b/app/src/main/res/layout/nav_header_main.xml
@@ -23,7 +23,7 @@
         android:text="@string/nav_header_title" />
 
     <TextView
-        android:id="@+id/textView"
+        android:id="@+id/nav_header_subtitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/nav_header_subtitle" />

--- a/app/src/main/res/layout/second_screen_logo.xml
+++ b/app/src/main/res/layout/second_screen_logo.xml
@@ -5,14 +5,45 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/second_screen_text_view"
+    <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hi I'm the secondary screen!"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:textSize="24dp"/>
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/second_screen_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Hi I'm the secondary screen!"
+            android:textSize="24dp" />
+
+        <Button
+            android:id="@+id/btn_red"
+            android:layout_width="240dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:backgroundTint="#d91e18"
+            android:text="Red Button" />
+
+        <Button
+            android:id="@+id/btn_yellow"
+            android:layout_width="240dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:backgroundTint="#f1c40f"
+            android:text="Yellow Button" />
+
+        <Button
+            android:id="@+id/btn_green"
+            android:layout_width="240dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:backgroundTint="#26a65b"
+            android:text="Green Button" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,10 +2,16 @@
     <string name="app_name">Android Presentation Display Demo</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
-    <string name="nav_header_title">Android Studio</string>
+    <string name="nav_header_title">Device Family</string>
     <string name="nav_header_subtitle">android.studio@android.com</string>
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
+
+    <!-- Secondary Accessory Display -->
+    <string name="notification_accessorydisplayservice_channel_name">Accessory Display Service Status</string>
+    <string name="notification_accessorydisplayservice_content_title">Accessory Display</string>
+    <string name="notification_accessorydisplayservice_content_text">Accessory Display Service Running</string>
+    <string name="notification_accessorydisplayservice_ticker">Starting Accessory Display Service</string>
 
     <string name="menu_transform">Transform</string>
     <string name="menu_admob">AdMob</string>


### PR DESCRIPTION
## Description:
- The secondary display now shows three buttons. Each of them will show a Snackbar when clicked by the customer.
- Borrow an icon from the Bootstrap Font Awesome library.
- Start the new `AccessoryDisplayService` when the demo app is running. It will show a Notification in the Android Status Bar.
- Start building the foundation of Intents, Broadcasts and Notifications to drive the lifecycle of the new Service (this is a work in progress).

## Related Issue(s):
https://gpproduct.atlassian.net/browse/PPA-9661