### PR TITLE
Add CfdHelper and increase compile sdk to 33

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.kevo.displaydemo"
-    compileSdk = 31
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "com.kevo.displaydemo"
         minSdk = 22
-        targetSdk = 31
+        targetSdk = 33
         versionCode = 1
         versionName = "1.0"
 
@@ -52,8 +52,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.0")
     implementation("androidx.annotation:annotation:1.2.0")
 
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
 
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "com.kevo.displaydemo"
-    compileSdk = 33
+    compileSdk = 31
 
     defaultConfig {
         applicationId = "com.kevo.displaydemo"
         minSdk = 22
-        targetSdk = 33
+        targetSdk = 31
         versionCode = 1
         versionName = "1.0"
 
@@ -52,8 +52,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.0")
     implementation("androidx.annotation:annotation:1.2.0")
 
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.1")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
 
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")

--- a/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
+++ b/app/src/main/java/com/kevo/displaydemo/MainActivity.kt
@@ -17,6 +17,7 @@ import com.google.android.material.navigation.NavigationView
 import com.kevo.displaydemo.databinding.ActivityMainBinding
 import com.kevo.displaydemo.service.ServiceManager
 import com.kevo.displaydemo.ui.BaseActivity
+import com.kevo.displaydemo.ui.secondarydisplay.CfdHelper
 import com.kevo.displaydemo.ui.secondarydisplay.PresentationHelper
 import com.kevo.displaydemo.ui.secondarydisplay.SimplePresentationFragment
 import com.kevo.displaydemo.util.DeviceHelper
@@ -106,6 +107,11 @@ class MainActivity : BaseActivity(), PresentationHelper.Listener {
         super.onPause()
     }
 
+    override fun onDestroy() {
+        CfdHelper.clearCommandQueue()
+        super.onDestroy()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         val result = super.onCreateOptionsMenu(menu)
         // Using findViewById because NavigationView exists in different layout files
@@ -136,10 +142,12 @@ class MainActivity : BaseActivity(), PresentationHelper.Listener {
 
     override fun showPreso(display: Display) {
         preso = SimplePresentationFragment(this, themeResourceId, display)
+        CfdHelper.setPreso(preso)
         preso!!.show(supportFragmentManager, SimplePresentationFragment.TAG)
     }
 
     override fun clearPreso() {
+        CfdHelper.setPreso(null)
         preso?.dismiss()
         preso = null
     }

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/CfdHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/CfdHelper.kt
@@ -1,0 +1,61 @@
+package com.kevo.displaydemo.ui.secondarydisplay
+
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+
+object CfdHelper {
+
+    private const val TAG = "CfdHelper"
+
+    private var lifecycle: Lifecycle? = null
+    private var preso: SimplePresentationFragment? = null
+    private val commandQueue = mutableListOf<Runnable>()
+
+    fun clearCommandQueue() {
+        commandQueue.clear()
+    }
+
+    fun setPreso(newPreso: SimplePresentationFragment?) {
+        preso = newPreso
+        lifecycle = newPreso?.lifecycle
+        newPreso?.lifecycle?.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                // Start executing any queued jobs if there are any
+                if (commandQueue.isNotEmpty()) {
+                    Log.i(TAG, "Launching coroutines for ${commandQueue.size} tasks in queue")
+
+                    owner.lifecycleScope.launch {
+                        // Iterate through the queue and launch a coroutine to complete each one
+                        for (runnable in commandQueue) {
+                            launch {
+                                runnable.run()
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    fun setText(newString: String) {
+        if (lifecycle != null) {
+            if (lifecycle!!.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                Log.i(TAG, "preso is ready to go setting text to $newString")
+
+                // The SimplePresentationFragment is ready to take commands
+                preso?.setText(newString)
+                return
+            }
+        }
+
+        Log.i(TAG, "preso not ready yet adding runnable to the queue")
+        // The SimplePresentationFragment is not ready to take commands yet
+        commandQueue.add(Runnable {
+            preso?.setText(newString)
+        })
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/CfdHelper.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/CfdHelper.kt
@@ -7,6 +7,12 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 
+/**
+ * A singleton helper class that acts as the messenger between our UI and the customer facing
+ * display (CFD). If a Fragment (or any other UI controller) calls one of these [CfdHelper]
+ * methods while the CFD's [SimplePresentationFragment] is not ready yet. [CfdHelper] will queue
+ * that command and execute it in a coroutine later when the [SimplePresentationFragment] is ready.
+ */
 object CfdHelper {
 
     private const val TAG = "CfdHelper"

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
@@ -56,6 +56,10 @@ class SimplePresentationFragment(
         _binding = null
     }
 
+    fun setText(newText: String) {
+        binding.secondScreenTextView.text = newText
+    }
+
     companion object {
 
         const val TAG = "SimplePresentationFragment"

--- a/app/src/main/java/com/kevo/displaydemo/ui/transform/TransformFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/transform/TransformFragment.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.kevo.displaydemo.R
 import com.kevo.displaydemo.databinding.FragmentTransformBinding
 import com.kevo.displaydemo.databinding.ItemTransformBinding
+import com.kevo.displaydemo.ui.secondarydisplay.CfdHelper
 
 /**
  * Fragment that demonstrates a responsive layout pattern where the format of the content
@@ -45,6 +46,9 @@ class TransformFragment : Fragment() {
         transformViewModel.texts.observe(viewLifecycleOwner) {
             adapter.submitList(it)
         }
+
+        CfdHelper.setText("Transform fragment wuz here")
+
         return root
     }
 
@@ -92,6 +96,9 @@ class TransformFragment : Fragment() {
             holder.imageView.setImageDrawable(
                 ResourcesCompat.getDrawable(holder.imageView.resources, drawables[position], null)
             )
+            holder.imageView.setOnClickListener {
+                CfdHelper.setText("Image at position $position clicked")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary:
`CfdHelper` is a singleton helper class that will act as the messenger between our fragments and the CFD. It is setup by `MainActivity`. It will observe the `PresentationFragment`'s lifecycle and if a fragment wants something to be be done on the CFD before `PresentationFragment` has been able to start up. Then `CfdHelper` will queue the command and execute any queued commands in coroutines after the `PresentationFragment` has reached it's Resumed state.

## Test Plan:
The `TransformFragment` (the first fragment the user lands on) will attempt to change the text on the CFD to say "Transform fragment wuz here" as soon as it starts up. This will almost always happen too soon and be put in queue.
- Verify the CFD text reads "Trasnform fragment wuz here" on startup

To test that commands work without going through the queue tap on any image in the `TransformFragment`.
- Verify the CFD text reads "Image at position <X> clicked"