### PR TITLE
Implement simple auto-slideshow using ViewPager2 on Customer-Facing screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.5.0")
     implementation("androidx.appcompat:appcompat:1.3.0")
     implementation("androidx.recyclerview:recyclerview:1.2.0")
+    implementation("androidx.viewpager2:viewpager2:1.1.0-beta01")
     implementation("androidx.constraintlayout:constraintlayout:2.1.0")
     implementation("androidx.annotation:annotation:1.2.0")
 

--- a/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/secondarydisplay/SimplePresentationFragment.kt
@@ -3,12 +3,26 @@ package com.kevo.displaydemo.ui.secondarydisplay
 import android.app.Presentation
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.Display
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.MainThread
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.kevo.displaydemo.R
 import com.kevo.displaydemo.databinding.CustomerPresentationScreenBinding
+import com.kevo.displaydemo.ui.slideshow.SlideItem
+import com.kevo.displaydemo.ui.slideshow.SlideItem.Key
+import com.kevo.displaydemo.ui.slideshow.SlidingImageAdapter
 import com.kevo.displaydemo.util.SnackbarHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import java.util.Timer
+import java.util.TimerTask
 
 /**
  * @param themedContext Should be a View context that contains UI theme information.
@@ -26,6 +40,12 @@ class SimplePresentationFragment(
 
     private var _binding: CustomerPresentationScreenBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var slidingImageAdapter: SlidingImageAdapter
+    private lateinit var viewPager: ViewPager2
+
+    private val foregroundEvents: CoroutineScope = MainScope()
+    private var timer: Timer? = null
 
     init {
         setDisplay(themedContext, themeResourceId, display)
@@ -48,7 +68,19 @@ class SimplePresentationFragment(
             }
         }
 
+        setupViewPager()
+
         return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        startOrResetTimer()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        timer?.cancel()
     }
 
     override fun onDestroyView() {
@@ -56,12 +88,70 @@ class SimplePresentationFragment(
         _binding = null
     }
 
+    private fun setupViewPager() = with(binding) {
+        viewPager = this.infiniteViewPager
+
+        val sliderImages = mutableListOf<SlideItem>()
+        sliderImages.add(
+            SlideItem(Key.CustomerOrderEntry, R.drawable.example_screen_customer_order_total)
+        )
+        sliderImages.add(
+            SlideItem(Key.LoyaltyPhone, R.drawable.example_screen_loyalty_phone)
+        )
+        sliderImages.add(
+            SlideItem(Key.ReceiptSelection, R.drawable.example_screen_receipt_selection)
+        )
+        sliderImages.add(
+            SlideItem(Key.SampleAd4, R.drawable.sample_ad_4)
+        )
+
+        slidingImageAdapter = SlidingImageAdapter(sliderImages, viewPager)
+        viewPager.adapter = slidingImageAdapter
+
+        viewPager.clipToPadding = false
+        viewPager.clipChildren = false
+        viewPager.offscreenPageLimit = 3
+        viewPager.getChildAt(0).overScrollMode = RecyclerView.OVER_SCROLL_NEVER
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                val item: SlideItem? = slidingImageAdapter.getItemAt(position)
+                // Useful for debugging
+                // Log.v(TAG, "Now showing item: ${item?.key}, ${item?.imageResId}")
+                when (item?.key) {
+                    Key.CustomerOrderEntry -> btnContainer.isVisible = true
+
+                    else -> btnContainer.isVisible = false
+                }
+            }
+        })
+    }
+
     fun setText(newText: String) {
         binding.secondScreenTextView.text = newText
     }
 
+    private fun startOrResetTimer() {
+        Log.d(TAG, "Resetting scheduled timer")
+
+        timer?.cancel()
+        timer = Timer().apply {
+            this.scheduleAtFixedRate(object : TimerTask() {
+                override fun run() {
+                    foregroundEvents.launch { transitionToNextSlide() }
+                }
+            }, AUTOMATIC_SLIDE_INTERVAL, AUTOMATIC_SLIDE_INTERVAL)
+        }
+    }
+
+    @MainThread
+    private fun transitionToNextSlide() {
+        Log.d(TAG, "Sliding to item ... ${viewPager.currentItem + 1}")
+        viewPager.currentItem = viewPager.currentItem + 1
+    }
+
     companion object {
 
-        const val TAG = "SimplePresentationFragment"
+        const val TAG = "SimplePresentFragment"
+        private const val AUTOMATIC_SLIDE_INTERVAL = 3_000L
     }
 }

--- a/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlideItem.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlideItem.kt
@@ -1,0 +1,13 @@
+package com.kevo.displaydemo.ui.slideshow
+
+import androidx.annotation.DrawableRes
+
+data class SlideItem(val key: Key, @DrawableRes val imageResId: Int) {
+
+    enum class Key {
+        CustomerOrderEntry,
+        LoyaltyPhone,
+        ReceiptSelection,
+        SampleAd4
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
@@ -1,0 +1,81 @@
+package com.kevo.displaydemo.ui.slideshow
+
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.kevo.displaydemo.R
+
+class SlidingImageAdapter(
+    private val items: MutableList<SlideItem>,
+    private val viewPager: ViewPager2
+) : RecyclerView.Adapter<SlidingImageAdapter.SliderViewHolder>() {
+
+    private val itemsCopy: List<SlideItem>
+
+    init {
+        assert(items.size >= 2) { "The Sliding Image Adapter requires at least 2 items" }
+        itemsCopy = items.toList()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SliderViewHolder {
+        return SliderViewHolder(
+            LayoutInflater.from(parent.context).inflate(
+                R.layout.slide_item_component, parent, false
+            )
+        )
+    }
+
+    override fun getItemCount(): Int {
+        return items.size
+    }
+
+    override fun onBindViewHolder(holder: SliderViewHolder, position: Int) {
+        holder.setImage(items[position])
+        if (position == items.size - 2) {
+            viewPager.post(extendCollectionRunnable)
+        }
+    }
+
+    private val extendCollectionRunnable = Runnable {
+        // TODO: Optimize this! (this will just balloon until we run out of memory)
+
+        // Take the first element and append it to the end of the array, to achieve
+        // the infinite scroll effect.
+        // val item = items.removeFirst()
+        // items.add(item)
+        // notifyItemInserted(items.size)
+
+        items.addAll(itemsCopy)
+        notifyItemInserted(items.size)
+    }
+
+    fun getItemAt(position: Int): SlideItem? {
+        return try {
+            items[position]
+        } catch (e: IndexOutOfBoundsException) {
+            Log.w(TAG, "Invalid position: $position")
+            null
+        }
+    }
+
+    class SliderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+        fun setImage(item: SlideItem) {
+            // Useful for debugging
+            // Log.d(TAG, "Now showing item: ${item.key}, ${item.imageResId}")
+
+            itemView.findViewById<ImageView>(R.id.image_slide)?.apply {
+                setImageResource(item.imageResId)
+            }
+        }
+    }
+
+    companion object {
+
+        const val TAG = "SlidingImageAdapter"
+    }
+}

--- a/app/src/main/res/layout/customer_presentation_screen.xml
+++ b/app/src/main/res/layout/customer_presentation_screen.xml
@@ -6,26 +6,23 @@
     android:layout_height="match_parent"
     android:background="#e0e0e0">
 
-    <ImageView
+    <View
         android:id="@+id/image_right_panel"
         android:layout_width="320dp"
         android:layout_height="match_parent"
         android:layout_marginEnd="4dp"
         android:layout_marginBottom="6dp"
-        android:contentDescription="@null"
-        android:scaleType="fitEnd"
-        android:src="@drawable/cart_with_products_example"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:background="#fae" />
 
-    <ImageView
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/infinite_view_pager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="fitCenter"
-        android:src="@drawable/example_screen_customer_order_total" />
+        android:layout_height="match_parent" />
 
+    <!-- TODO: Either hide this when irrelevant slides are shown, or remove it altogether -->
     <androidx.appcompat.widget.LinearLayoutCompat
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -62,6 +59,7 @@
     </androidx.appcompat.widget.LinearLayoutCompat>
 
     <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/btn_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"

--- a/app/src/main/res/layout/slide_item_component.xml
+++ b/app/src/main/res/layout/slide_item_component.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/image_slide"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:scaleType="fitCenter"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:src="@drawable/example_screen_customer_order_total" />


### PR DESCRIPTION
## Description:
The `Carousel` was too complicated and required too many moving parts to maintain - a simple `ViewPager2` implementation is cleaner, requires less code, and can be more seamlessly dropped into other applications.

Still need to optimize and work out the infinite items array that is currently just ballooning out of control after hours of sitting idle. I'm sure it's an easy fix, and it may require overriding the `setCurrentItem()` function for the view pager.

Also, the Red + Yellow + Green buttons will be hidden for all slides other than the primary "Order Entry" slide.

## Related Issue(s):
https://gpproduct.atlassian.net/browse/PPA-9661