### PR TITLE
Minor refactor to introduce an InfiniteSlidePager wrapper

### DIFF
--- a/app/src/main/java/com/kevo/displaydemo/ui/slideshow/InfiniteSlidePager.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/slideshow/InfiniteSlidePager.kt
@@ -1,0 +1,14 @@
+package com.kevo.displaydemo.ui.slideshow
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+
+class InfiniteSlidePager(val viewPager: ViewPager2) {
+
+    init {
+        viewPager.clipToPadding = false
+        viewPager.clipChildren = false
+        viewPager.offscreenPageLimit = 3
+        viewPager.getChildAt(0).overScrollMode = RecyclerView.OVER_SCROLL_NEVER
+    }
+}

--- a/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
@@ -5,16 +5,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.annotation.MainThread
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.kevo.displaydemo.R
 
 class SlidingImageAdapter(
     private val items: MutableList<SlideItem>,
-    private val viewPager: ViewPager2
+    infiniteSlidePager: InfiniteSlidePager
 ) : RecyclerView.Adapter<SlidingImageAdapter.SliderViewHolder>() {
 
     private val itemsCopy: List<SlideItem>
+    private val viewPager: ViewPager2 = infiniteSlidePager.viewPager
 
     init {
         assert(items.size >= 2) { "The Sliding Image Adapter requires at least 2 items" }
@@ -34,6 +36,7 @@ class SlidingImageAdapter(
     }
 
     override fun onBindViewHolder(holder: SliderViewHolder, position: Int) {
+        Log.v(TAG, "onBindViewHolder :: position $position items.size ${items.size}")
         holder.setImage(items[position])
         if (position == items.size - 2) {
             viewPager.post(extendCollectionRunnable)
@@ -42,6 +45,7 @@ class SlidingImageAdapter(
 
     private val extendCollectionRunnable = Runnable {
         // TODO: Optimize this! (this will just balloon until we run out of memory)
+        Log.i(TAG, "Rearranging content of items collection ...")
 
         // Take the first element and append it to the end of the array, to achieve
         // the infinite scroll effect.
@@ -60,6 +64,12 @@ class SlidingImageAdapter(
             Log.w(TAG, "Invalid position: $position")
             null
         }
+    }
+
+    @MainThread
+    fun transitionToNextSlide() {
+        Log.d(TAG, "transitionToNextSlide :: Sliding to item ... ${viewPager.currentItem + 1}")
+        viewPager.currentItem = viewPager.currentItem + 1
     }
 
     class SliderViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {


### PR DESCRIPTION
Description:
Still working on figuring out a cleaner implementation for the infinite slide item transitions, rather than just extending the contents of the collection in perpetuity (which is horrible for memory, eventually).

This slight refactor should be beneficial if we need to tweak the `ViewPager2` implementation, and helps move some boilerplate out of our `Fragment`.

Related Issue(s):
https://gpproduct.atlassian.net/browse/PPA-9661