### PR TITLE
Add infinite scroll to the ViewPager2 in SimplePresentationFragment

### DIFF
--- a/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
+++ b/app/src/main/java/com/kevo/displaydemo/ui/slideshow/SlidingImageAdapter.kt
@@ -38,9 +38,6 @@ class SlidingImageAdapter(
     override fun onBindViewHolder(holder: SliderViewHolder, position: Int) {
         Log.v(TAG, "onBindViewHolder :: position $position items.size ${items.size}")
         holder.setImage(items[position])
-        if (position == items.size - 2) {
-            viewPager.post(extendCollectionRunnable)
-        }
     }
 
     private val extendCollectionRunnable = Runnable {


### PR DESCRIPTION
## Summary:
The previous solution for infinite scrolling had us growing the size of the list infinitely until we ran out of memory. Change this so the ViewPager2 can scroll infinitely programatically.

## Test Plan:
- Verify the ViewPager2 on the CFD can be scrolled forever in both directions and loops around when you get through all the pages.